### PR TITLE
Remove inlined picture references from the plain text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,9 @@
+## Next
+
+Remove inlined picture references from the plain text
+
+## v1.0.1 2015-03-20
+
+Updated html-to-text
+
+## v1.0.0 2014-07-30

--- a/src/nodemailer-html-to-text.js
+++ b/src/nodemailer-html-to-text.js
@@ -31,6 +31,7 @@ HTMLToText.prototype.process = function(mail, done) {
         }
         try {
             mail.data.text = converter.fromString(html, this._options);
+            mail.data.text = mail.data.text.replace(/(\n)\[cid:.*?\] |\[cid:.*?\]/g, '$1');
         } catch (E) {
             return done(E);
         }

--- a/test/nodemailer-html-to-text-test.js
+++ b/test/nodemailer-html-to-text-test.js
@@ -28,6 +28,46 @@ describe('nodemailer-html-to-text tests', function() {
         });
     });
 
+    it('should remove the inlined picture reference including the empty space behind a line break', function(done) {
+        var plugin = htmlToText();
+        var mail = {
+            data: {
+                html: '<p>Tere, tere</p><p><img src="cid:nodemailerLogo"/>vana kere!</p>'
+            },
+            resolveContent: function(obj, key, cb) {
+                cb(null, obj[key]);
+            }
+        };
+        plugin(mail, function(err) {
+            expect(err).to.not.exist;
+            console.log(JSON.stringify(mail.data.text));
+            expect(mail.data.text).to.equal(
+                'Tere, tere\n\nvana kere!'
+            );
+            done();
+        });
+    });
+
+    it('should remove the inlined picture reference and keep the empty space without line break', function(done) {
+        var plugin = htmlToText();
+        var mail = {
+            data: {
+                html: '<p>Tere,<img src="cid:nodemailerLogo"/> tere</p><p>vana kere!</p>'
+            },
+            resolveContent: function(obj, key, cb) {
+                cb(null, obj[key]);
+            }
+        };
+        plugin(mail, function(err) {
+            expect(err).to.not.exist;
+            console.log(JSON.stringify(mail.data.text));
+            expect(mail.data.text).to.equal(
+                'Tere, tere\n\nvana kere!'
+            );
+            done();
+        });
+    });
+
     it('should set text from html buffer', function(done) {
         var plugin = htmlToText();
         var mail = {


### PR DESCRIPTION
This will remove the empty space that is added after a line break and keep it if there's no line break after the reference.

This closes #3 