### PR TITLE
Updated html-to-text package dependency version

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   },
   "homepage": "https://github.com/andris9/nodemailer-html-to-text",
   "dependencies": {
-    "html-to-text": "^1.3.1"
+    "html-to-text": "^1.3.2"
   },
   "devDependencies": {
     "chai": "~3.2.0",


### PR DESCRIPTION
The new package version just removes a warning for Node 4 engine.

Would appreciate if you like and merge if you could bump this package's version too. :+1: 