### PR TITLE
Update html-to-text to 2.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nodemailer-html-to-text",
-  "version": "1.0.2",
+  "version": "2.0.0",
   "description": "Generate text content from html for Nodemailer e-mails",
   "main": "src/nodemailer-html-to-text.js",
   "directories": {

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   },
   "homepage": "https://github.com/andris9/nodemailer-html-to-text",
   "dependencies": {
-    "html-to-text": "^1.3.2"
+    "html-to-text": "^2.1.0"
   },
   "devDependencies": {
     "chai": "~3.2.0",


### PR DESCRIPTION
Introduces some new useful features from html-to-text. The only [breaking change](https://github.com/werk85/node-html-to-text/blob/929dfa69a18f2d0fe9cb4d4424ac039108d54246/CHANGELOG.md#version-200) in html-to-text@2 is that the mimimum node version was increased to `>=0.10.0`; so if you'd like to maintain that perhaps you could release a new major version. This has the nice side-effect that this module stays in sync with versions of html-to-text.