### PR TITLE
Upgraded html-to-text dependency

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: node_js
 node_js:
-  - "0.10"
-  - 0.12
-  - iojs
+  - "4"
+  - "6"
+  - "8"
 
 before_install:
   - npm install -g grunt-cli

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # CHANGELOG
 
+## v2.2.0 2018-06-26
+
+Upgraded node-html-text to 4.0.0
+Updated dev dependencies
+Deprecate Node versions < 4
+
 ## v2.1.0 2016-04-11
 
 Upgraded node-html-text

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nodemailer-html-to-text",
-  "version": "2.1.0",
+  "version": "3.0.0",
   "description": "Generate text content from html for Nodemailer e-mails",
   "main": "src/nodemailer-html-to-text.js",
   "directories": {
@@ -23,13 +23,16 @@
   },
   "homepage": "https://github.com/andris9/nodemailer-html-to-text",
   "dependencies": {
-    "html-to-text": "^2.1.0"
+    "html-to-text": "^4.0.0"
   },
   "devDependencies": {
-    "chai": "~3.5.0",
-    "grunt": "~1.0.1",
-    "grunt-contrib-jshint": "~1.0.0",
-    "grunt-mocha-test": "~0.12.7",
-    "mocha": "^2.4.5"
+    "chai": "~4.1.2",
+    "grunt": "~1.0.3",
+    "grunt-contrib-jshint": "~1.1.0",
+    "grunt-mocha-test": "~0.13.3",
+    "mocha": "^5.2.0"
+  },
+  "engines": {
+    "node": ">= 4.0.0"
   }
 }

--- a/src/nodemailer-html-to-text.js
+++ b/src/nodemailer-html-to-text.js
@@ -1,12 +1,12 @@
 'use strict';
 
-var converter = require('html-to-text');
+const converter = require('html-to-text');
 
 module.exports.htmlToText = function(options) {
     options = options || {};
 
     return function(mail, done) {
-        var handler = new HTMLToText(options);
+        const handler = new HTMLToText(options);
         handler.process(mail, done);
     };
 };


### PR DESCRIPTION
Because of a transient dependency on underscore.string, there is a vulnerability for ReDOS (see https://snyk.io/vuln/npm:underscore.string:20170908). Upgrade to html-to-text 4.0.0 solves the issue.

Since that dependency needs Node >=4, I also added an engines setting and updated the Travis config.

I've bumped version to 3.0.0 because of the Node version deprecation.

